### PR TITLE
Changed all Tree class imports to be uniform

### DIFF
--- a/ex1/lib/parsing/earley/parse_trees.py
+++ b/ex1/lib/parsing/earley/parse_trees.py
@@ -2,7 +2,7 @@
 # coding=utf-8
 # -*- encoding: utf-8 -*-
 
-from adt.tree import Tree
+from lib.adt.tree import Tree
 
 
 class ParseTrees:

--- a/ex1/lib/parsing/silly/__init__.py
+++ b/ex1/lib/parsing/silly/__init__.py
@@ -2,7 +2,7 @@
 import re
 from collections.abc import Iterable
 
-from adt.tree import Tree
+from lib.adt.tree import Tree
 from ..earley.sentence import Word
 
 

--- a/ex1/src/lambda_calc/lambda_types.py
+++ b/ex1/src/lambda_calc/lambda_types.py
@@ -7,7 +7,7 @@ Implement type checking and type inference for simply-typed lambda calculus.
 
 from lambda_calc.syntax import LambdaParser, pretty
 from lambda_calc.stdlib import CONSTANTS
-from adt.tree import Tree
+from lib.adt.tree import Tree
 
 
 def type_inference(expr: Tree) -> (Tree, Tree):

--- a/ex1/src/lambda_calc/syntax.py
+++ b/ex1/src/lambda_calc/syntax.py
@@ -1,5 +1,5 @@
 from functools import reduce
-from adt.tree import Tree
+from lib.adt.tree import Tree
 from parsing.earley.earley import Grammar, Parser, ParseTrees
 from parsing.silly import SillyLexer
 


### PR DESCRIPTION
Importing the same Tree class using different paths caused the interpreter to treat it as different classes.
This caused comparison of trees to fail, depending on where were they created.

For example:
```python
from adt.tree import Tree
t1 = Tree('x')
from lib.adt.tree import Tree
t2 = Tree('x')
print(t1 == t2) # prints False
```

(tested on python 3.11)